### PR TITLE
Feature/#5 디버깅툴 reactotron 적용

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -21,7 +21,11 @@ function App() {
 let AppEntryPoint = App;
 
 if (process.env.STORYBOOK_ENABLED) {
-  AppEntryPoint = require("./.ondevice").default;
+  AppEntryPoint = require('./.ondevice').default;
+}
+
+if (__DEV__) {
+  require('./ReactotronConfig');
 }
 
 export default AppEntryPoint;

--- a/apps/app/ReactotronConfig.js
+++ b/apps/app/ReactotronConfig.js
@@ -1,4 +1,8 @@
-import Reactotron, {networking} from 'reactotron-react-native';
+import Reactotron, {
+  networking,
+  trackGlobalErrors,
+  trackGlobalLogs,
+} from 'reactotron-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 Reactotron.setAsyncStorageHandler(AsyncStorage)
@@ -9,4 +13,6 @@ Reactotron.setAsyncStorageHandler(AsyncStorage)
     asyncStorage: true,
   })
   .use(networking())
+  .use(trackGlobalErrors())
+  .use(trackGlobalLogs())
   .connect();

--- a/apps/app/ReactotronConfig.js
+++ b/apps/app/ReactotronConfig.js
@@ -1,0 +1,11 @@
+import Reactotron from 'reactotron-react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+Reactotron.setAsyncStorageHandler(AsyncStorage)
+  .configure({
+    name: 'greeenai',
+  })
+  .useReactNative({
+    asyncStorage: true,
+  })
+  .connect();

--- a/apps/app/ReactotronConfig.js
+++ b/apps/app/ReactotronConfig.js
@@ -1,4 +1,4 @@
-import Reactotron from 'reactotron-react-native';
+import Reactotron, {networking} from 'reactotron-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 Reactotron.setAsyncStorageHandler(AsyncStorage)
@@ -8,4 +8,5 @@ Reactotron.setAsyncStorageHandler(AsyncStorage)
   .useReactNative({
     asyncStorage: true,
   })
+  .use(networking())
   .connect();

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^4.6.4",
-    "@react-native-async-storage/async-storage": "^2.0.0",
+    "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-community/datetimepicker": "^8.2.0",
     "@react-native-community/slider": "^4.5.3",
     "react": "18.3.1",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -73,6 +73,7 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "18.3.1",
+    "reactotron-react-native": "^5.1.10",
     "storybook": "^8.3.5",
     "typescript": "5.0.4"
   },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,4 +4,4 @@ import { createVanillaExtractPlugin } from "@vanilla-extract/next-plugin";
 const nextConfig = {};
 const withVanillaExtract = createVanillaExtractPlugin();
 
-module.exports = withVanillaExtract(nextConfig);
+export default withVanillaExtract(nextConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         specifier: ^4.6.4
         version: 4.6.4(@types/react-native@0.73.0)(@types/react@18.3.1)(react-native-gesture-handler@2.21.2)(react-native-reanimated@3.16.5)(react-native@0.75.3)(react@18.3.1)
       '@react-native-async-storage/async-storage':
-        specifier: ^2.0.0
+        specifier: ^2.1.0
         version: 2.1.0(react-native@0.75.3)
       '@react-native-community/datetimepicker':
         specifier: ^8.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      reactotron-react-native:
+        specifier: ^5.1.10
+        version: 5.1.10(react-native@0.75.3)
       storybook:
         specifier: ^8.3.5
         version: 8.4.7(prettier@2.8.8)
@@ -10726,6 +10729,10 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  /mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+    dev: true
+
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -12026,6 +12033,26 @@ packages:
   /react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
+
+  /reactotron-core-client@2.9.6:
+    resolution: {integrity: sha512-7krCkKn/uy8VF1UhSmgrhYsPJ2VNJ+btYSG0S8NBlhW/EtsRHUtLQy+tbBVg2cHaTHbejY4qrvr0yP5L7L2Osw==}
+    dependencies:
+      reactotron-core-contract: 0.2.4
+    dev: true
+
+  /reactotron-core-contract@0.2.4:
+    resolution: {integrity: sha512-CmNYahBdk9uES4vimlRsoM1gAQA6T5gXTuJzDvduOjKd0IZufZjkxzBAvhpkX5OIkPl4Xlsv+1AHXLWSJSwFLA==}
+    dev: true
+
+  /reactotron-react-native@5.1.10(react-native@0.75.3):
+    resolution: {integrity: sha512-CD20odAESgH0K2YJCyfJLQg5K5Ho1qnk0QBB3SjD1yjt5BJhPuHjdXFyuED8PYLgOz+YwOX7jyK2/wu3TCp1OQ==}
+    peerDependencies:
+      react-native: '>=0.40.0'
+    dependencies:
+      mitt: 3.0.1
+      react-native: 0.75.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0)(@types/react@18.3.1)(react@18.3.1)(typescript@5.0.4)
+      reactotron-core-client: 2.9.6
+    dev: true
 
   /readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #5
