### PR TITLE
Refactor/#60 패키지 name 통일

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,5 @@
 import Image, { type ImageProps } from "next/image";
-import { Button } from "@repo/ui/button";
+import { Button } from "@greeenai/ui/button";
 import styles from "./page.module.css";
 
 type Props = Omit<ImageProps, "src"> & {

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,4 +1,4 @@
-import { nextJsConfig } from "@repo/eslint-config/next-js";
+import { nextJsConfig } from "@greeenai/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
 export default nextJsConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "greeenai-web",
   "version": "0.1.0",
   "type": "module",
   "private": true,
@@ -13,7 +13,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@repo/ui": "workspace:*",
+    "@greeenai/ui": "workspace:*",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/nextjs.json",
+  "extends": "@greeenai/typescript-config/nextjs.json",
   "compilerOptions": {
     "plugins": [
       {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "greeen-ai",
+  "name": "greeenai",
   "private": true,
   "scripts": {
     "build": "turbo build",
@@ -12,8 +12,8 @@
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
-    "@repo/eslint-config": "workspace:*",
-    "@repo/typescript-config": "workspace:*",
+    "@greeenai/eslint-config": "workspace:*",
+    "@greeenai/typescript-config": "workspace:*",
     "husky": "^9.1.7",
     "lint-staged": "^15.2.11",
     "prettier": "^3.2.5",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/eslint-config",
+  "name": "@greeenai/eslint-config",
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/typescript-config",
+  "name": "@greeenai/typescript-config",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -1,4 +1,4 @@
-import { config } from "@repo/eslint-config/react-internal";
+import { config } from "@greeenai/eslint-config/react-internal";
 
 /** @type {import("eslint").Linter.Config} */
 export default config;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/ui",
+  "name": "@greeenai/ui",
   "version": "0.0.0",
   "type": "module",
   "private": true,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "@greeenai/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,10 @@ importers:
 
   .:
     devDependencies:
-      '@repo/eslint-config':
+      '@greeenai/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config
-      '@repo/typescript-config':
+      '@greeenai/typescript-config':
         specifier: workspace:*
         version: link:packages/typescript-config
       '@types/jest':
@@ -162,7 +162,7 @@ importers:
 
   apps/web:
     dependencies:
-      '@repo/ui':
+      '@greeenai/ui':
         specifier: workspace:*
         version: link:../../packages/ui
       next:


### PR DESCRIPTION
<!-- PR 제목 한 번 확인해주세요!
브랜치 이름 + 주된 작업 요약
ex. feat/#1 프로젝트 세팅 -->

### **요약 (Summary)**

<!-- 가장 먼저 테크 스펙을 세 줄 내외로 정리합니다. 테크 스펙의 제안 전체에 대해 누가/무엇을/언제/어디서/왜를 간략하면서도 명확하게 적습니다.

> Bottom Navigation 영역(하단 탭)을 유저가 원하는 순서로 커스텀할 수 있게 합니다. 서버에 순서 정렬 및 저장 API를 요청할 수 없으므로, 순서를 로컬에 저장하고 불러옵니다. -->

### **배경 (Background)**

<!-- 프로젝트의 Context를 적습니다. 왜 이 기능을 만드는지, 동기는 무엇인지, 어떤 사용자 문제를 해결하려 하는지, 이전에 이런 시도가 있었는지, 있었다면 해결이 되었는지 등을 포함합니다.

> 다양한 탭을 사용하는 유저는 Segment에 따라 하단 탭의 노출 수와 사용 빈도가 다릅니다. 예를 들어, 20대와 30대의 추천 탭 노출 수 사이는 월 n만 정도입니다. 이러한 유저의 Segment에 맞춰 하단 탭 순서를 유저가 직접 커스텀할 수 있다면 뱅크샐러드가 개인화되었다고 인지할 수 있을 것입니다. -->

### **목표 (Goals)**

<!-- 예상 결과들을 Bullet Point 형태로 나열합니다. 이 목표들과 측정 가능한 임팩트들을 이용해 추후 이 프로젝트의 성공 여부를 평가합니다.

> Bottom Navigation의 순서를 유저가 편집할 수 있게 한다.앱을 껐다 켰을 시에도 유저가 편집한 순서대로 하단 탭을 보이게 한다. -->

### **이외 고려 사항들 (Other Considerations)**

<!-- 고려했었으나 하지 않기로 결정된 사항들을 적습니다. 이렇게 함으로써 이전에 논의되었던 주제가 다시 나오지 않도록 할 수 있고, 이미 논의되었던 내용이더라도 리뷰어들이 다시 살펴볼 수 있습니다.

> 앱 데이터 초기화 시에는 사용자가 커스텀했던 리스트를 모두 날리기로 했었으나, 기존 로직에서 앱 데이터 초기화 시에 로컬 관련 추가 핸들링이 없어 이 기능에서도 앱 데이터 초기화 때에 리스트를 날리는 등 추가적인 기능 구현을 하지 않기로 함. -->

#### 관련 이슈

- resolved #60
